### PR TITLE
Remove Cobo Connect from navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -579,14 +579,6 @@
                   "en/walletconnect/connect-and-send-transaction"
                 ]
               },
-              {
-                "group": "Cobo Connect",
-                "pages": [
-                  "en/cobo-connect/introduction",
-                  "en/cobo-connect/set-up",
-                  "en/cobo-connect/interact-with-dapps"
-                ]
-              }
             ]
           },
           {
@@ -1172,14 +1164,6 @@
                   "cn/walletconnect/connect-and-send-transaction"
                 ]
               },
-              {
-                "group": "Cobo Connect",
-                "pages": [
-                  "cn/cobo-connect/introduction",
-                  "cn/cobo-connect/set-up",
-                  "cn/cobo-connect/interact-with-dapps"
-                ]
-              }
             ]
           },
           {


### PR DESCRIPTION
Hide Cobo Connect pages from the docs site navigation by removing their entries from docs.json (both cn and en). The source files are kept in place.