### PR TITLE
Fix Portal Mobile setup entry in quick-start docs 

### DIFF
--- a/cn/portal/glossary.mdx
+++ b/cn/portal/glossary.mdx
@@ -25,7 +25,7 @@ API Key 是密钥对中的公钥，用于识别发起 API 请求的客户端。A
 Cobo Connect 是一个 Chrome 扩展程序，使您能够将 Cobo Portal 钱包与 dApp 连接。建立连接后，Cobo Connect 将识别来自 dApp 的每个交易和消息，并根据您在 Cobo Portal 中预先配置的风控规则处理它们。
 
 ### Portal Mobile
-Portal Mobile 是一款多功能安全 iOS App，提升您在移动端的数字资产安全性和保护。它作为 MPC 密钥分片管理器和多重身份验证（MFA）方式，用于审批登录和交易等操作。
+Portal Mobile 是一款多功能安全移动 App，支持 iOS 与 Android，提升您在移动端的数字资产安全性和保护。它作为 MPC 私钥分片管理器和多重身份验证（MFA）方式，用于审批登录和交易等操作。
 
 ### Cobo Portal
 Cobo Portal 是一个一站式平台，为您提供安全高效的数字资产管理方式。凭借其经过实战检验的安全架构和对代币及链的广泛支持，Cobo Portal 提供多种加密钱包以满足您的特定需求。此外，它还提供了广泛的功能，包括全面的风控措施、无缝访问 Web3/DeFi 网络、直观的数据概览，以及丰富的 Cobo 和第三方 App 选择。

--- a/cn/portal/mpc-wallets/ocw/set-up.mdx
+++ b/cn/portal/mpc-wallets/ocw/set-up.mdx
@@ -8,7 +8,7 @@ description: "学习如何设置机构钱包，确保顺利开始资产管理。
 ## 前提条件
 
 - 您已按照[快速入门指南](/cn/portal/quick-start-guide-mpc)设置帐户并完成其他必要步骤。 
-- 您已下载 Portal Mobile 并按照屏幕上的说明在 iOS 设备上完成设置。
+- 您已下载 Portal Mobile 并按照屏幕上的说明在移动设备（iOS 或 Android）上完成设置。
 - 您已被分配[操作员](/cn/portal/organization/roles-and-permissions)或具有同等权限的角色。
 
 ## 步骤

--- a/cn/portal/quick-start-asset.mdx
+++ b/cn/portal/quick-start-asset.mdx
@@ -25,7 +25,7 @@ og:description: "了解如何快速设置和管理全托管钱包。分步指南
 ## 前提条件
 
 - [联系我们的销售团队](https://www.cobo.com/zh/book-demo?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)获取您的账户激活链接。
-- 一台用于运行 [Portal Mobile](/cn/portal-mobile/introduction) 的 iOS 设备，这是我们专门用于多重身份验证（MFA）、操作审批、交易签名和私钥分片管理的应用程序。
+- 一台用于运行 [Portal Mobile](/cn/portal-mobile/introduction) 的移动设备（iOS 或 Android），Portal Mobile 是我们专门用于多重身份验证（MFA）、操作审批、交易签名和私钥分片管理的应用程序。
 
 ## 注册并激活账户
 
@@ -37,9 +37,10 @@ og:description: "了解如何快速设置和管理全托管钱包。分步指南
 注册后您可通过 [https://portal.dev.cobo.com/login](https://portal.dev.cobo.com/login) 登录 Cobo Portal 开发环境。
 
 ## 设置 Portal Mobile
-登录[开发环境](https://portal.dev.cobo.com/login)的 Cobo Portal，在左下角的弹窗中点击**绑定 Portal Mobile**。按照屏幕上的说明在您的 iOS 设备上安装 Portal Mobile，并将您的账户与 Portal Mobile 关联。
-
-如果提示框被关闭，可点击左侧菜单的**指南**重新打开。
+1. 登录[开发环境](https://portal.dev.cobo.com/login)的 Cobo Portal。
+2. 点击右上角的个人头像，选择 **Account**，切换到 **Security** 标签页。
+3. 在 **Multi-Factor Authentication (MFA)** 区域，找到 **Cobo Portal Mobile** 一行，点击右侧的 **Set Up**。
+4. 按照屏幕上的说明在您的移动设备上安装 Portal Mobile，并将您的账户与 Portal Mobile 关联。详细步骤请参阅[设置 Portal Mobile](/cn/portal-mobile/set-up)。
 
 绑定目的：
 - 作为 Cobo Portal 的 MFA 认证方式。

--- a/cn/portal/quick-start-guide-custodial-wallets.mdx
+++ b/cn/portal/quick-start-guide-custodial-wallets.mdx
@@ -18,7 +18,7 @@ import MySnippet2 from '/snippets/transfer-category-and-description-cn.mdx';
 
 * [联系我们的销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)获取您的账户激活链接。
 
-* 一台 iOS 设备，用于运行 [Portal Mobile](/cn/portal-mobile/introduction)（Cobo 开发的 iOS 应用，用于多重身份验证和操作审批）。
+* 一台移动设备（iOS 或 Android），用于运行 [Portal Mobile](/cn/portal-mobile/introduction)，Cobo 开发的移动应用，用于多重身份验证和操作审批。
 
 <MySnippet />
 

--- a/cn/portal/quick-start-guide-mpc.mdx
+++ b/cn/portal/quick-start-guide-mpc.mdx
@@ -20,7 +20,7 @@ import Snippet from '/snippets/account-setup-cn.mdx';
 
 * [联系我们的销售团队](https://www.cobo.com/zh/book-demo?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)获取您的账户激活链接。
 
-* 一台用于运行 [Portal Mobile](/cn/portal-mobile/introduction) 的 iOS 设备，这是我们专门用于多重身份验证（MFA）、操作审批、交易签名和私钥分片管理的应用程序。
+* 一台用于运行 [Portal Mobile](/cn/portal-mobile/introduction) 的移动设备（iOS 或 Android），Portal Mobile 是我们专门用于多重身份验证（MFA）、操作审批、交易签名和私钥分片管理的应用程序。
 
 <Snippet />
 

--- a/cn/portal/quick-start-mpc.mdx
+++ b/cn/portal/quick-start-mpc.mdx
@@ -30,7 +30,7 @@ og:description: "学习如何在 Cobo Portal 开发环境中设置和使用 MPC 
 ## 前提条件
 
 - [联系我们的销售团队](https://www.cobo.com/zh/book-demo?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)获取您的账户激活链接。
-- 一台用于运行 [Portal Mobile](/cn/portal-mobile/introduction) 的 iOS 设备，这是我们专门用于多重身份验证（MFA）、操作审批、交易签名和私钥分片管理的应用程序。
+- 一台用于运行 [Portal Mobile](/cn/portal-mobile/introduction) 的移动设备（iOS 或 Android），Portal Mobile 是我们专门用于多重身份验证（MFA）、操作审批、交易签名和私钥分片管理的应用程序。
 
 ## 注册并激活账户
 
@@ -42,9 +42,10 @@ og:description: "学习如何在 Cobo Portal 开发环境中设置和使用 MPC 
 注册后您可通过 [https://portal.dev.cobo.com/login](https://portal.dev.cobo.com/login) 登录 Cobo Portal 开发环境。
 
 ## 设置 Portal Mobile
-登录[开发环境](https://portal.dev.cobo.com/login)的 Cobo Portal，在左下角的弹窗中点击**绑定 Portal Mobile**。按照屏幕上的说明在您的 iOS 设备上安装 Portal Mobile，并将您的账户与 Portal Mobile 关联。
-
-如果提示框被关闭，可点击左侧菜单的**指南**重新打开。
+1. 登录[开发环境](https://portal.dev.cobo.com/login)的 Cobo Portal。
+2. 点击右上角的个人头像，选择 **Account**，切换到 **Security** 标签页。
+3. 在 **Multi-Factor Authentication (MFA)** 区域，找到 **Cobo Portal Mobile** 一行，点击右侧的 **Set Up**。
+4. 按照屏幕上的说明在您的移动设备上安装 Portal Mobile，并将您的账户与 Portal Mobile 关联。详细步骤请参阅[设置 Portal Mobile](/cn/portal-mobile/set-up)。
 
 绑定目的：
 - 作为 Cobo Portal 的 MFA 认证方式。

--- a/en/portal/glossary.mdx
+++ b/en/portal/glossary.mdx
@@ -25,7 +25,7 @@ Asset Wallets are a subtype of Custodial Wallets, which allow you to transfer to
 Cobo Connect is a Chrome extension that enables you to connect your Cobo Portal wallets with dApps. After you make the connection, Cobo Connect will identify each transaction and message from the dApps and process them based on your pre-configured risk control policies in Cobo Portal.
 
 ### Portal Mobile
-Portal Mobile is a multifunctional security iOS application designed to elevate the safety and protection of your digital assets on the go. It functions as an MPC key share manager and a multi-factor authentication (MFA) method for approvals on operations, including login and transactions.
+Portal Mobile is a multifunctional security mobile application available on iOS and Android, designed to elevate the safety and protection of your digital assets on the go. It functions as an MPC key share manager and a multi-factor authentication (MFA) method for approvals on operations, including login and transactions.
 
 ### Cobo Portal
 Cobo Portal is an all-in-one platform designed to provide a secure and efficient way to manage your digital assets. With its battle-tested security architecture and unparalleled support for tokens and chains, Cobo Portal offers a range of crypto wallets to cater to your specific needs. Additionally, it offers a wide array of features, including comprehensive risk controls, seamless access to Web3/DeFi networks, intuitive data dashboards, and a rich selection of both Cobo and third-party applications.

--- a/en/portal/mpc-wallets/ocw/set-up.mdx
+++ b/en/portal/mpc-wallets/ocw/set-up.mdx
@@ -8,7 +8,7 @@ description: "Follow the steps to set up an Organization-Controlled Wallet, incl
 ## Prerequisites
 
 - You have set up your account and complete other required steps following the [Quick start guide](/en/portal/quick-start-guide-mpc).
-- You have downloaded [Portal Mobile](/en/portal-mobile/download) and follow the on-screen instructions to set up Portal Mobile on your iOS devices.
+- You have downloaded [Portal Mobile](/en/portal-mobile/download) and followed the on-screen instructions to set up Portal Mobile on your mobile device (iOS or Android).
 - You have been assigned the [Operator](/en/portal/organization/roles-and-permissions) role or a role with equivalent permissions.
 
 ## Steps

--- a/en/portal/quick-start-asset.mdx
+++ b/en/portal/quick-start-asset.mdx
@@ -25,7 +25,7 @@ This guide will walk you through the step-by-step process to set up and use Cust
 ## Prerequisites
 
 - [Contact our sales team](https://www.cobo.com/book-demo?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) to get your account activation link.
-- An iOS device to run [Portal Mobile](/en/portal-mobile/introduction), our app for multi-factor authentication (MFA), operation approval, transaction signing, and private key share management.
+- A mobile device (iOS or Android) to run [Portal Mobile](/en/portal-mobile/introduction), our app for multi-factor authentication (MFA), operation approval, transaction signing, and private key share management.
 
 ## Register and activate Cobo Accounts
 
@@ -39,9 +39,10 @@ After activation, you can login to the development environment of Cobo Portal vi
 
 ## Set up Portal Mobile
 
-Log in to the [development environment](https://portal.dev.cobo.com/login) of Cobo Portal, and click **Set Up Portal Mobile** in the pop-up at the lower left corner. Follow the on-screen instructions to install Portal Mobile on your iOS device and link your account to it.
-
-If the pop-up is closed, click **Guide** in the left-hand menu to reopen it.
+1. Log in to the [development environment](https://portal.dev.cobo.com/login) of Cobo Portal.
+2. Click your profile avatar in the top-right corner, select **Account**, and switch to the **Security** tab.
+3. In the **Multi-Factor Authentication (MFA)** section, find the **Cobo Portal Mobile** row and click **Set Up** on the right.
+4. Follow the on-screen instructions to install Portal Mobile on your mobile device and link your account with Portal Mobile. For detailed steps, see [Set up Portal Mobile](/en/portal-mobile/set-up).
 
 Purpose of setting up Portal Mobile:
 

--- a/en/portal/quick-start-guide-custodial-wallets.mdx
+++ b/en/portal/quick-start-guide-custodial-wallets.mdx
@@ -18,7 +18,7 @@ This quick start guide helps you explore and evaluate Cobo's [Custodial Wallets]
 
 * [Contact our sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) to acquire your account activation link.
 
-* An iOS device to run [Portal Mobile](/en/portal-mobile/introduction), an iOS app designed by Cobo for multi-factor authentication (MFA) and operation approval.
+* A mobile device (iOS or Android) to run [Portal Mobile](/en/portal-mobile/introduction), a mobile app designed by Cobo for multi-factor authentication (MFA) and operation approval.
 
 <MySnippet />
 

--- a/en/portal/quick-start-guide-mpc.mdx
+++ b/en/portal/quick-start-guide-mpc.mdx
@@ -20,7 +20,7 @@ This guide provides a step-by-step walkthrough for setting up and using MPC Wall
 
 * [Contact our sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) to acquire your account activation link.
 
-* An iOS device to run [Portal Mobile](/en/portal-mobile/introduction), our dedicated app for multi-factor authentication (MFA), operation approval, transaction signing, and key share management.
+* A mobile device (iOS or Android) to run [Portal Mobile](/en/portal-mobile/introduction), our dedicated app for multi-factor authentication (MFA), operation approval, transaction signing, and key share management.
 
 <Snippet />
 

--- a/en/portal/quick-start-mpc.mdx
+++ b/en/portal/quick-start-mpc.mdx
@@ -30,7 +30,7 @@ This guide will walk you through the step-by-step process to set up and use MPC 
 ## Prerequisites
 
 - [Contact our sales team](https://www.cobo.com/book-demo?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) to get your account activation link.
-- An iOS device to run [Portal Mobile](/en/portal-mobile/introduction), our app for multi-factor authentication (MFA), operation approval, transaction signing, and private key share management.
+- A mobile device (iOS or Android) to run [Portal Mobile](/en/portal-mobile/introduction), our app for multi-factor authentication (MFA), operation approval, transaction signing, and private key share management.
 
 ## Register and activate Cobo Accounts
 
@@ -44,9 +44,10 @@ After activation, you can login to the development environment of Cobo Portal vi
 
 ## Set up Portal Mobile
 
-Log in to the [development environment](https://portal.dev.cobo.com/login) of Cobo Portal, and click **Set Up Portal Mobile** in the pop-up at the lower left corner. Follow the on-screen instructions to install Portal Mobile on your iOS device and link your account to it.
-
-If the pop-up is closed, click **Guide** in the left-hand menu to reopen it.
+1. Log in to the [development environment](https://portal.dev.cobo.com/login) of Cobo Portal.
+2. Click your profile avatar in the top-right corner, select **Account**, and switch to the **Security** tab.
+3. In the **Multi-Factor Authentication (MFA)** section, find the **Cobo Portal Mobile** row and click **Set Up** on the right.
+4. Follow the on-screen instructions to install Portal Mobile on your mobile device and link your account with Portal Mobile. For detailed steps, see [Set up Portal Mobile](/en/portal-mobile/set-up).
 
 Purpose of setting up Portal Mobile:
 


### PR DESCRIPTION


- Rewrite the "Set up Portal Mobile" section in the four quick-start articles (MPC and Custodial, free trial and paid) to match the
  current UI: profile avatar (top-right) > Account > Security >
  Multi-Factor Authentication (MFA) > Cobo Portal Mobile > Set Up. Drop the obsolete "bottom-left pop-up" and "left-menu Guide" steps, which were removed from the product.
- Update prerequisites in quick-start and MPC wallet set-up docs to state "a mobile device (iOS or Android)" instead of "an iOS device", reflecting that Portal Mobile is now distributed on both the App Store and Google Play.
- Fix the Portal Mobile glossary entry, which incorrectly described the app as iOS-only.