### PR TITLE
docs: 完善充币未到账排查、Memo/Tag 提示及 Screening 人工审核时间说明

### DIFF
--- a/cn/apps/screening/screening-settings.mdx
+++ b/cn/apps/screening/screening-settings.mdx
@@ -71,6 +71,10 @@ Screening 设置允许您自定义应用的运行方式，包括 AML 服务商�
 
     <Note>阶梯金额扫描策略适用于使用 **Elliptic**、**CipherOwl**、**BlockSec** 或**自定义服务商**的团队；使用 **Cobo Premium** 时不支持该策略。</Note>
 
+## 人工审核处理时间
+
+处于人工审核中的交易，在决策通过 API 或 Screening 应用提交之前，将持续保持在 Cobo Portal 的 **Pending Screening** 状态。
+
 ## 通知设置
 
 管理重要扫描事件的邮件通知接收人。
@@ -82,4 +86,3 @@ Screening 设置允许您自定义应用的运行方式，包括 AML 服务商�
 </Note>
 
 <Info>必须保留至少一个接收人 - 您不能删除唯一剩余的接收人。</Info>
-

--- a/cn/portal/supported-tokens-and-chains.mdx
+++ b/cn/portal/supported-tokens-and-chains.mdx
@@ -163,3 +163,6 @@ Cobo Portal 目前支持超过 80 条区块链和 3,000 多种代币。
 
 <Note>您还可以通过[列出支持的链 API](https://www.cobo.com/developers/v2/api-references/wallets/list-supported-chains#response-data-confirming-threshold) 查询 `confirming_threshold` 字段。</Note>
 
+<Note>部分链或资产的充币还要求填写 Memo/Tag/备注。请在 Cobo Portal 充币地址弹窗中查看该币种/链对应的 Memo/Tag 字段及提示信息，以确认是否需要填写。</Note>
+
+<Note>充币实际到账等待时间取决于上表所需的确认数以及当前网络的出块速度，可能因网络拥堵而变化。如需查看某笔充币的实时进度，请在 Cobo Portal 充币地址弹窗中查看该币种/链对应的实时确认数。</Note>

--- a/cn/portal/troubleshoot/deposit-not-credited.mdx
+++ b/cn/portal/troubleshoot/deposit-not-credited.mdx
@@ -16,11 +16,16 @@ description: "了解充币长时间未到账时的常见原因与排查步骤。
 2. 核对充币信息是否正确
     - 充币地址是否正确。
     - 充币链/网络是否正确。
-    - 若该链或资产要求填写 Tag/Memo/备注，请确认填写无误。
+    - 若该链或资产要求填写 Tag/Memo/备注，请注意：**转账**页面下展示的需要备注的链列表仅适用于转出交易，不适用于充币。发送资金前，请在 Cobo Portal 充币地址弹窗中查看该币种/链对应的 Memo/Tag 字段及提示信息。
 
-3. 检查是否存在入账延迟的常见原因
+3. 检查合规扫描与资产支持情况
+    - 如果 Cobo Portal 中的交易状态显示为 **Pending Screening**，或包含 **Pending Cobo KYT Screening**、**Pending Screening App Check** 等子状态，说明该笔充币正处于合规审核中。详情请参阅 [Screening 简介](/cn/apps/screening/introduction) 与 [Screening 设置](/cn/apps/screening/screening-settings)。
+    - 如果交易状态显示为 **Screening Rejected**，或包含 **Rejected by Cobo KYT**、**Rejected by Screening App** 等子状态，说明该笔充币已被您所在团队的合规策略拒绝。请参阅 [Screening 简介](/cn/apps/screening/introduction) 与 [Screening 设置](/cn/apps/screening/screening-settings) 以核查策略配置。
+    - 如果充值的代币或链目前尚不支持，请参阅 [自助上币](/cn/portal/self-service-token-listing) 申请上线支持。
+
+4. 检查是否存在入账延迟的常见原因
     - 网络拥堵导致确认时间变长。
-    - 部分 Layer2 网络（如 Arbitrum、Optimism、Base、Zora 等）需要等待 L1 最终确认（Finalized）后才会入账：即使您在 L2 浏览器中看到交易成功，也可能需要等待该交易在 L1 达到 Finalized 状态后，平台侧才会完成入账。
+    - 部分 Layer2 网络（如 Arbitrum、Optimism、Base、Zora 等）需要等待 L1 最终确认（Finalized）后才会入账：即使您在 L2 浏览器中看到交易成功，也可能需要等待该交易在 L1 达到 Finalized 状态后，平台侧才会完成入账。Cobo Portal 充币地址弹窗会展示该 L1 最终确认提示以及该币种的实时确认数，您可据此查看入账进度。
     - 系统维护或服务异常。
 
 如需查询 Cobo Portal 对不同链的入账确认数要求，请参阅[支持的代币与链](/cn/portal/supported-tokens-and-chains#代币入账确认数)。

--- a/en/apps/screening/screening-settings.mdx
+++ b/en/apps/screening/screening-settings.mdx
@@ -66,7 +66,11 @@ Customize how transaction screening behaves in different scenarios.
     Tiers must start at 0, be continuous (each tier's lower bound equals the previous tier's upper bound), and end with an open-ended catch-all tier (no upper bound). By default, internal transactions are bypassed and external transactions are screened.
 
     <Note>Tiered screening policies are available for teams using **Elliptic**, **CipherOwl**, **BlockSec**, or a **Custom Provider**. They are not supported when using **Cobo Premium**.</Note>
-    
+
+## Manual review processing time
+
+A transaction awaiting manual review remains in the **Pending Screening** status in Cobo Portal until a decision is submitted, either through the API or in the Screening app.
+
 ## Notification Settings
 
 Manage who receives email notifications about important screening events.
@@ -78,4 +82,3 @@ It is recommended to include your Risk Management and Compliance teams as notifi
 </Note>
 
 <Info>At least one recipient must remain - you cannot delete the only remaining recipient.</Info>
-

--- a/en/portal/supported-tokens-and-chains.mdx
+++ b/en/portal/supported-tokens-and-chains.mdx
@@ -163,3 +163,6 @@ The table below lists the minimum number of confirmations required for token dep
 
 <Note>You can also query the `confirming_threshold` field through the [List supported chains API](https://www.cobo.com/developers/v2/api-references/wallets/list-supported-chains#response-data-confirming-threshold).</Note>
 
+<Note>Some chains or assets also require a Memo/Tag/Note for deposits. To check whether a specific token or chain requires one, refer to the Memo/Tag field and any warning shown in the deposit address modal in Cobo Portal.</Note>
+
+<Note>The actual wait time for a deposit to be credited depends on the number of confirmations required (shown above) and the current block production speed of the network, which can vary with network congestion. To check progress for a specific deposit, refer to the live confirmation count shown in the deposit address modal in Cobo Portal.</Note>

--- a/en/portal/troubleshoot/deposit-not-credited.mdx
+++ b/en/portal/troubleshoot/deposit-not-credited.mdx
@@ -16,11 +16,16 @@ If your deposit hasn’t been credited for a long time, we recommend checking th
 2. Verify your deposit information
     - Ensure the deposit address is correct.
     - Ensure the chain/network is correct.
-    - If the chain/asset requires a Tag/Memo/Note, ensure it is provided correctly.
+    - If the chain/asset requires a Tag/Memo/Note, note that the list of memo-required chains shown under **Transfers** applies to outbound transfers only and does not apply to deposits. Before sending funds, check the Memo/Tag field and any warning shown in the deposit address modal in Cobo Portal for the specific token and chain you are depositing.
 
-3. Check common causes of crediting delays
+3. Check compliance screening and asset support
+    - If the transaction status in Cobo Portal shows **Pending Screening**, or a sub-status such as **Pending Cobo KYT Screening** or **Pending Screening App Check**, the deposit is being held for compliance review. Learn more in [Introduction to Screening](/en/apps/screening/introduction) and [Configure Screening settings](/en/apps/screening/screening-settings).
+    - If the transaction status shows **Screening Rejected**, or a sub-status such as **Rejected by Cobo KYT** or **Rejected by Screening App**, the deposit was rejected by your organization's compliance policy. Refer to [Introduction to Screening](/en/apps/screening/introduction) and [Configure Screening settings](/en/apps/screening/screening-settings) to review your policy configuration.
+    - If the deposited token or chain is not currently supported, refer to [Self-service token listing](/en/portal/self-service-token-listing) to request support for it.
+
+4. Check common causes of crediting delays
     - Network congestion leading to longer confirmation time.
-    - Some Layer 2 networks (such as Arbitrum, Optimism, Base, and Zora) require L1 finality (Finalized) before the deposit is credited. Even if the transaction shows as successful on the L2 explorer, it may still need to reach Finalized on L1 before it can be credited.
+    - Some Layer 2 networks (such as Arbitrum, Optimism, Base, and Zora) require L1 finality (Finalized) before the deposit is credited. Even if the transaction shows as successful on the L2 explorer, it may still need to reach Finalized on L1 before it can be credited. The deposit address modal in Cobo Portal surfaces this L1-finality caveat and the live confirmation count for the specific token, so you can check progress there.
     - System maintenance or service incidents.
 
 To learn the confirmation requirements for deposits on different chains, refer to [Supported tokens and chains](/en/portal/supported-tokens-and-chains#required-confirmation-for-token-deposits).


### PR DESCRIPTION
## 关联来源

（未在 intent/feedback 中发现 Phabricator / Aladdin / Slack 关联链接）

## 意图

本次变更针对 product-manual 文档站（en/ 与 cn/ 镜像）中「充币未到账」排查页与 Screening 设置页的缺口进行补充，来源于用户反馈中按优先级排序的四类问题：(1) 充币 Memo/Tag 提示过于笼统（最高优先级）；(2) 缺少指向合规扫描（Screening）与不支持资产上币申请的跳转链接（低成本快速改进）；(3) 人工审核处理时长缺失说明（受限于业务数据，暂不给出具体数字）；(4) 到账时间缺乏可估算的说明（优先级最低）。

## 变更摘要

- `en/portal/troubleshoot/deposit-not-credited.mdx`：将第 19 行笼统的 Memo/Tag 提示改为充币方向的专属说明（明确「转账」页展示的清单仅适用于转出，不适用于充币，需在 Portal 充币地址弹窗核对）；新增「检查合规扫描与资产支持情况」分支（Pending Screening / Screening Rejected 及子状态说明并跳转 Screening 相关页面；不支持资产跳转自助上币页）；补充 L2 最终确认提示中关于 Portal 弹窗展示实时确认数的说明。
- `cn/portal/troubleshoot/deposit-not-credited.mdx`：镜像上述英文改动的中文版本。
- `en/apps/screening/screening-settings.mdx`：新增「Manual review processing time」小节，仅说明人工审核期间交易保持 Pending Screening 状态直至决策提交，不给出具体 SLA 时长（该数字需合规/风控团队确认，暂缺）。
- `cn/apps/screening/screening-settings.mdx`：镜像上述英文改动的中文版本（人工审核处理时间小节）。
- `en/portal/supported-tokens-and-chains.mdx`：在「Required confirmation for token deposits」表格旁新增两条 Note：(a) 部分链/资产充币还需 Memo/Tag，请在 Portal 充币地址弹窗核对；(b) 实际到账等待时间取决于所需确认数与当前出块速度，可在弹窗查看实时确认数，不提供具体到账时长换算。
- `cn/portal/supported-tokens-and-chains.mdx`：镜像上述英文改动的中文版本。

## 代码证据

- `custody/waas2/coins/core/helper.py:86-88`、`custody/waas2/coins/bo.py:25`、`custody/waas2/coins/bo_v2.py:76`、`custody/waas2/coins/managers.py:185-187` — 证明 `use_memo_to_deposit` 与 `use_memo_to_withdraw` 在后端按链独立配置于 DB，充币与转出的 Memo 要求并非同一份清单，支撑「转账页清单不适用于充币」的措辞。
- `custody-2.0-website/.../DepositModal/index.tsx:119-123`、`custody-2.0-website/src/locales/en-US/custodial.ts:128` — 证明 Portal 充币地址弹窗基于 `tokenInfo.requireMemo` 实时展示 Memo/Tag 提示，支撑「请在弹窗核对」的引导。
- `custody/waas2/compliance/compliance/enums/enums.py:160,157,144,324`、`custody/waas2/transaction_query/enums/transaction_query.py:48,50,60,77,91,92` — 证明后端存在 `PendingScreening`/`Rejected`/`RejectedByScreeningApp`/`RejectedByCoboKyt` 等状态与子状态枚举，支撑排查步骤中引用的状态名称。
- `custody-2.0-website/src/locales/en-US/common.ts:181,183,184,187`、`custody-2.0-website/src/locales/en-US/transaction.ts:199,201,204,206`、`custody-2.0-website/src/utils/transaction.tsx:329` — 证明 Portal UI 实际展示的英文状态/子状态文案（Pending Screening、Screening Rejected、Pending Cobo KYT Screening、Pending Screening App Check、Rejected by Cobo KYT、Rejected by Screening App），文档中引用的状态字符串与其逐字一致。
- `custody/waas2/transactions/mongo/manager/tests/test_timeline.py:157,160` — 证明人工审核期间交易状态确为 `PendingScreening`，支撑「人工审核处理时间」小节中「保持 Pending Screening 直至决策提交」的表述。
- `custody-2.0-website/src/locales/en-US/custodial.ts:123,126` — 证明 Portal 充币弹窗展示实时确认数模板与 L2 最终确认提示文案，支撑到账时间说明中「可在弹窗查看实时确认数」的引导。
- `custody/waas2/coins/core/helper.py:85,126,480` — 证明 `confirming_threshold` 按链/资产在 DB 配置读取，与文档中确认数表格一致；同时确认该模块中未发现平均出块时间字段（用于说明为何不提供换算后的具体等待时长）。

## ⚠️ 待确认事项

- **待人工确认**：充币方向（inbound）需要 Memo/Tag 的权威链清单——已确认后端按链独立配置 `use_memo_to_deposit`（`custody/waas2/coins/core/helper.py:86-88` 等），但未找到可读的、汇总所有链配置结果的清单来源，因此文档未列出具体链名，需产品/链上团队确认后补充。
- **待人工确认**：Memo/Tag 缺失的具体后果（资金无法识别/需人工找回/可能无法找回）——未在已检索代码中找到明确定义，需产品/运营团队确认。
- **待人工确认**：`cross-links-cn` 分支中引用的中文 Portal 状态文案（如「Pending Screening」是否在 zh-CN 语言包中有对应中文展示名）——仅确认了 en-US locale 字符串（`custody-2.0-website/src/locales/en-US/common.ts:181` 等），未检索 zh-CN locale，建议做一次 UI 文案核对。
- **待人工确认**：人工审核处理时长的具体 SLA 数字——`custody/waas2/compliance/compliance/` 中未发现任何 SLA/turnaround 常量，此数字需合规/风控团队提供，目前文档中未给出（未使用占位符 TBC，直接省略该数字，仅说明状态保持逻辑）。
- **待人工确认**：确认数换算为具体等待时长所需的平均出块时间，以及 Arbitrum/Optimism/Base/Zora 等 L2 的 L1 最终确认典型时长——`custody/waas2/coins/` 中未发现平均出块时间配置，需与链上团队确认后再补充具体时长或换算说明。
