### PR TITLE
docs: 完善 Portal Webhook 配置与事件恢复说明

### DIFF
--- a/cn/portal/developer-console/webhook-events.mdx
+++ b/cn/portal/developer-console/webhook-events.mdx
@@ -11,3 +11,14 @@ import Snippet from '/snippets/webhook-events-cn.mdx';
 
 <Snippet />
 
+## 查看事件详情
+
+点击列表中的任意事件即可打开其详情页。详情页显示完整的事件负载，以及每次投递尝试的记录，包括时间戳和您的 Endpoint 针对该次投递返回的 HTTP 状态码。
+
+## 重新发送失败的事件
+
+如果某个事件的状态为**发送失败**或**重试中**，点击**重试**即可触发一次新的投递尝试。
+
+## 通过 API 查询事件历史
+
+您还可以使用 [List all webhook events](https://www.cobo.com/developers/v2/api-references/developers--webhooks/list-all-webhook-events) 操作查询 Endpoint 最多 30 天的 Webhook 事件历史。有关完整的恢复流程，包括查看指定事件、列出每次投递尝试、通过 API 重试，以及核对交易当前状态，请参阅 Developer Hub 中的 [设置 Callback 或 Webhook Endpoint](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/set-up-endpoint)。

--- a/cn/portal/developer-console/webhooks-create.mdx
+++ b/cn/portal/developer-console/webhooks-create.mdx
@@ -13,6 +13,8 @@ description: "学习如何创建 Webhook Endpoint，确保与外部服务的有�
 ## 前提条件
 您已按照 [Set up a callback or webhook endpoint](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/set-up-endpoint) 中的说明设置了 Webhook Endpoint。
 
+每个 Webhook Endpoint 适用于您的整个组织。您只需配置一次，即可在团队内共享，而非绑定到单个用户。注册 Endpoint 时，您必须至少选择一个要接收的事件类型。您还可以选择接收组织内所有钱包的事件，或将投递范围限制为选定的钱包。
+
 ## 步骤
 
 1. 登录 [Cobo Portal](https://portal.cobo.com/login)。
@@ -23,9 +25,10 @@ description: "学习如何创建 Webhook Endpoint，确保与外部服务的有�
 
 4. 输入 URL。
 5. 输入 Webhook 的描述。
-6. 选择您想要接收的事件通知类型。
+6. 在**事件通知订阅**下，选择您希望此 Endpoint 接收的事件类型。您必须至少选择一个事件类型才能保存 Endpoint。
     <Note>欲了解更多事件类型的详情，请参阅 [Webhook event types](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/webhook-event-type#webhook-event-types)。</Note>
-7. 点击**注册**。
+7. 选择接收组织内所有钱包的事件，或仅接收选定钱包的事件。
+8. 点击**注册**。
 
 至此，您已完成 Webhook Endpoint 的注册。Webhook Endpoint 一旦注册后将无法删除。但是如果您不再需要，您可以让它失效，这意味着永久禁用其功能。
 
@@ -37,3 +40,9 @@ description: "学习如何创建 Webhook Endpoint，确保与外部服务的有�
 - 根据状态或事件类型过滤 Webhook Endpoint 列表。
 - 使用名称或关键字搜索特定的 Webhook Endpoint。
 
+## 相关资源
+
+- [Webhooks 和 Callbacks 简介](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/introduction)：了解负载结构、事件类型和核对流程。
+- [设置 Callback 或 Webhook Endpoint](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/set-up-endpoint)：实现 Endpoint 的事件处理逻辑。
+- [Transaction 负载参考](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/wallets-transaction-payload)：查看完整的 `wallets.transaction` Webhook 负载结构。
+- [TSS request 负载参考](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/wallets-mpc-tss-request-payload)：查看完整的 `wallets.mpc.tss_request` Webhook 负载结构。

--- a/en/portal/developer-console/webhook-events.mdx
+++ b/en/portal/developer-console/webhook-events.mdx
@@ -11,3 +11,14 @@ You can easily manage the webhook events in Developer by clicking on the corresp
 
 <Snippet />
 
+## View event details
+
+Click any event in the list to open its details. The detail view shows the full event payload and a log of every delivery attempt, including the timestamp and the HTTP status code your endpoint returned for that attempt.
+
+## Resend a failed event
+
+If an event's status is **Failed** or **Retrying**, click **Retry** to trigger a new delivery attempt to your endpoint.
+
+## Query event history via the API
+
+You can also query up to 30 days of webhook event history for an endpoint using the [List all webhook events](https://www.cobo.com/developers/v2/api-references/developers--webhooks/list-all-webhook-events) operation. For a full recovery workflow, including inspecting a specific event, listing every delivery attempt, retrying via the API, and reconciling against the current transaction state, see [Set up a callback or webhook endpoint](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/set-up-endpoint) in Developer Hub.

--- a/en/portal/developer-console/webhooks-create.mdx
+++ b/en/portal/developer-console/webhooks-create.mdx
@@ -13,6 +13,8 @@ If your server has firewall or security group rules that restrict access by IP a
 ## Prerequisites
 You have set up your webhook endpoint as described in [Set up a callback or webhook endpoint](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/set-up-endpoint).
 
+Each webhook endpoint applies to your organization as a whole. Configure it once to share it across your team rather than tying it to a single user. When you register the endpoint, you must select at least one event type for it to receive. You can also limit delivery to selected wallets or receive events for all wallets in your organization.
+
 ## Steps
 
 1. Log in to [Cobo Portal](https://portal.cobo.com/login).
@@ -24,9 +26,10 @@ You have set up your webhook endpoint as described in [Set up a callback or webh
 
 5. Enter the URL.
 6. Enter a description for the webhook endpoint.
-7. Select the types of event notifications you want to subscribe to.
+7. Under **Event Notification Subscriptions**, select the event types you want this endpoint to receive. Select at least one event type to save the endpoint.
     <Note>For more details about the event types, refer to [Webhook event types](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/webhook-event-type#webhook-event-types).</Note>
-8. Click **Register**.
+8. Choose whether to receive events for all wallets in your organization or only for selected wallets.
+9. Click **Register**.
 
 Now you have registered a webhook endpoint. After registering the webhook endpoint, you cannot delete it. However, if it's no longer needed, you can revoke it, which will permanently disable its functionality.
 
@@ -38,3 +41,9 @@ After registering a webhook endpoint, you can:
 - Filter the webhook endpoint list by status or event type.
 - Search for specific webhook endpoints using names or keywords.
 
+## Related resources
+
+- [Introduction to webhooks and callbacks](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/introduction): Learn about payload structures, event types, and reconciliation.
+- [Set up a callback or webhook endpoint](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/set-up-endpoint): Implement your endpoint's event-handling logic.
+- [Transaction payload reference](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/wallets-transaction-payload): Review the complete `wallets.transaction` webhook payload schema.
+- [TSS request payload reference](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/wallets-mpc-tss-request-payload): Review the complete `wallets.mpc.tss_request` webhook payload schema.


### PR DESCRIPTION
## 关联来源

- https://pha.1cobo.com/T96128
- Aladdin 工单：1128876036453798224
- Aladdin 工单：1126429538992722086
- 关联 primary PR：https://github.com/CoboGlobal/developer-site/pull/386

## 意图

完善 Cobo Portal 中 Webhook Endpoint 的配置与事件管理说明，解决客户对订阅作用域、钱包范围、事件负载参考和失败投递恢复流程不清楚的问题。明确 Endpoint 按组织配置、事件类型与钱包范围的选择方式，并补充事件详情、投递尝试、手动重试和 30 天 API 查询窗口。通过 Developer Hub 链接串联完整负载参考与交易核对流程。

## 变更摘要

- `en/portal/developer-console/webhooks-create.mdx`：补充组织级 Endpoint 配置、必选事件类型、钱包范围选择及相关 Developer Hub 参考链接。
- `cn/portal/developer-console/webhooks-create.mdx`：同步中文 Endpoint 作用域、事件订阅、钱包范围与相关参考说明。
- `en/portal/developer-console/webhook-events.mdx`：补充事件详情、投递尝试记录、失败或重试中事件的手动重试，以及 30 天 API 查询与恢复流程链接。
- `cn/portal/developer-console/webhook-events.mdx`：同步中文事件详情、投递日志、手动重试、30 天查询窗口与恢复流程说明。

## 代码证据

- `custody/waas2/webhooks/controller/webhook_endpoint.py:22`：Endpoint 创建时绑定请求组织，并保存 URL、订阅事件和可选钱包范围。
- `custody-2.0-website/src/pages/Developers/Webhooks/AddOrWebhooksModal/index.tsx:215`：Portal 的 Webhook Endpoint 配置界面要求明确选择钱包范围。
- `custody-2.0-website/src/pages/Developers/Events/Detail/index.tsx:125`：Portal 允许对 `Failed` 或 `Retrying` 状态的 Webhook 事件执行重新发送。
- `custody-2.0-website/src/pages/Developers/Events/Detail/index.tsx:160`：Portal 事件详情页展示每次投递尝试的记录。
- `developer-site-waas2/v2/cobo_waas2_openapi_spec/paths/webhooks/events.yaml:6`：`List all webhook events` 提供最近 30 天的事件查询窗口。

## ⚠️ 待确认事项

无
