### PR TITLE
docs: 完善 Webhook 事件恢复指引

### DIFF
--- a/snippets/webhook-events-cn.mdx
+++ b/snippets/webhook-events-cn.mdx
@@ -4,6 +4,12 @@
 - **时间** <img src="/cn/images/developer-console/button_time.svg" className="icon"></img>：选择显示某一时间段内的所有 Webhook 事件。
 - **事件** <img src="/cn/images/developer-console/button_event.svg" className="icon"></img>：从下拉菜单中勾选事件通知类型。
 - **全部清除** <img src="/cn/images/developer-console/button_clear all.svg" className="icon"></img>：移除所有已选中的条件。
-- **重试** <img src="/cn/images/developer-console/button_retry.svg" className="icon"></img>：当状态为“发送失败”或“重试中”时，用户可以重新发送事件。
+- **重新发送** <img src="/cn/images/developer-console/button_retry.svg" className="icon"></img>：重新发送该事件给您的 Endpoint。此操作需要具备重新发送 Webhook 事件的权限；如果没有该权限，单击重新发送会显示权限提示，而不会重新发送事件。如果该事件的状态不是 `Failed` 或 `Retrying`（例如该事件已成功投递），Cobo Portal 会要求您确认后才能重新发送，因为对已投递事件重新发送可能导致您的 Endpoint 处理重复数据。
+- **事件详情**：单击某个事件可查看其 `Time`、`Event ID` 和 `URL`。当状态为 `Retrying` 时，详情中还会显示 `Next Retry Time` 和 `No. of Retries Left`。
+- **Webhook 尝试**：在事件详情下方，可查看该事件投递到您 Endpoint 的每一次尝试记录。查看尝试记录需要具备与重新发送不同的独立查看权限。
 
 如您想要了解 Webhook Events 的行为以及更多详情，请参阅 [Webhook events](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/set-up-endpoint#webhook-events)。
+
+在单击重新发送之前，请先修复您 Endpoint 上的问题；在未解决根本原因的情况下重新发送只会导致同样的失败。有关完整的恢复流程（包括查找受影响的事件、检查投递日志，以及对账交易状态），请参阅开发者中心的[恢复遗漏或失败的事件](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/webhook-operations#恢复遗漏或失败的事件)。
+
+如果某个事件在 Cobo Portal 或 API 中已不再可见，说明其投递历史已过期。请直接通过 Transaction API 对账该交易的当前状态；请参阅开发者中心的[历史记录已过期时](https://www.cobo.com/developers/v2_cn/guides/webhooks-callbacks/webhook-operations#历史记录已过期时)。

--- a/snippets/webhook-events-en.mdx
+++ b/snippets/webhook-events-en.mdx
@@ -4,6 +4,12 @@
 - **Time** <img src="/en/images/developer-console/button_time.svg" className="icon"></img>: Select a timeframe to display all webhook events within that time period.
 - **Event** <img src="/en/images/developer-console/button_event.svg" className="icon"></img>: Tick the type of event notification from the drop-down menu.
 - **Clear All** <img src="/en/images/developer-console/button_clear all.svg" className="icon"></img>: Remove all selected conditions.
-- **Retry** <img src="/en/images/developer-console/button_retry.svg" className="icon"></img>: When the status is either "Failed" or "Retrying", the user can resubmit the event.
+- **Retry** <img src="/en/images/developer-console/button_retry.svg" className="icon"></img>: Resubmit the event to your endpoint. This action requires permission to resend webhook events; if you do not have it, choosing Retry shows a permission notice instead of resending. If the event's status is not `Failed` or `Retrying` (for example, it was already delivered), Cobo Portal asks you to confirm before resending, because retrying a delivered event can cause your endpoint to process duplicate data.
+- **Event details**: Click an event to view its `Time`, `Event ID`, and `URL`. When the status is `Retrying`, the details also show `Next Retry Time` and `No. of Retries Left`.
+- **Webhook Attempts**: Below the event details, view the delivery log for each attempt made to your endpoint. Viewing attempts requires a separate view permission from the one required to retry.
 
 For more details on the behaviors of the webhook events, refer to [Webhook events](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/set-up-endpoint#webhook-events).
+
+Before you click Retry, fix the issue on your endpoint. Resending without addressing the root cause produces the same failure. For a complete recovery workflow — including finding affected events, inspecting delivery logs, and reconciling transaction state — see [Recover missed or failed events](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/webhook-operations#recover-missed-or-failed-events) in the Developer Hub.
+
+If an event is no longer visible in Cobo Portal or through the API, its delivery history has expired. Reconcile the transaction's current state directly through the transaction APIs; see [When history has expired](https://www.cobo.com/developers/v2/guides/webhooks-callbacks/webhook-operations#when-history-has-expired) in the Developer Hub.


### PR DESCRIPTION
## 关联来源

- https://pha.1cobo.com/T96128
- Aladdin 工单：1128876036453798224
- Aladdin 工单：1126429538992722086
- 关联 primary PR：https://github.com/CoboGlobal/developer-site/pull/387

## 意图

T96128 汇总了 126 条 H1 Webhook 和事件类型反馈，其中约 70% 与 payload、字段或状态语义有关。本次变更补充 Cobo Portal 中 Webhook 事件的权限、重试元数据、投递日志和恢复步骤，并引导用户在事件历史过期后通过 Transaction API 对账，避免在未确认公开保留期限的情况下给出具体时长。

## 变更摘要

- `snippets/webhook-events-en.mdx`：完善英文 Webhook 事件详情、权限化 Retry、投递日志检查、Endpoint 修复和过期后对账指引，并链接 Developer Hub 恢复流程。
- `snippets/webhook-events-cn.mdx`：同步中文 Webhook 事件恢复流程，保留状态、权限和操作标识符。

## 代码证据

- `custody-2.0-website/src/pages/Developers/Events/Detail/index.tsx:26`：Cobo Portal 的事件重新发送操作受权限控制。
- `custody-2.0-website/src/services/developers/index.ts:181`：Cobo Portal 通过 `POST /webhooks/events/{event_id}/retries` 发起手动重新发送。
- `custody/waas2/webhooks/views/event_retries.py:19`：公开重新发送接口要求 `WEBHOOK RESEND` 权限并按组织范围执行。
- `custody/waas2/webhooks/client/client.py:302`：投递日志查询按 Endpoint 和事件范围执行，并支持游标分页。

## ⚠️ 待确认事项

- **待人工确认** `portal-retention-en`：已检索 Custody 本地 Webhook outbox 清理逻辑和下游事件查询接口，但未找到下游 Webhook 服务对公开事件及投递日志的保留期限；需人工核实公开 TTL、归档或删除策略及环境差异。
- **待人工确认** `portal-retention-cn`：同上，中文页面暂不写入未经证实的保留时长；需在下游服务确认后同步准确期限。
