### PR TITLE
docs: 明确 Custody Fee Station 与 Payments Fee Management 边界

### DIFF
--- a/cn/portal/fee-station/deposit.mdx
+++ b/cn/portal/fee-station/deposit.mdx
@@ -5,6 +5,8 @@ lang: "zh-hans"
 description: "了解如何在 Fee Station 进行充币操作，确保您的资产安全转入。"
 ---
 
+<Info>本页介绍如何向 Cobo Custody 的 Fee Station 充值。Fee Station 用于为 Cobo Portal 上的 MPC 钱包（机构钱包）和 Web3 钱包预付交易费用及 Cobo 账单。如果您使用 Cobo Payments，请前往 [Fee Management](https://www.cobo.com/payments/cn/guides/fee-management) 为您的 Payments 费用余额充值。</Info>
+
 <Note>您可以向 Fee Station 充值以自动支付交易费用。请注意，这目前仅适用于从 Cobo Portal 网页上的 MPC 钱包（机构钱包）和全托管钱包（Web3 钱包）发起的 EVM 和 TRON 交易。</Note>
 
 1. 登录 [Cobo Portal](https://portal.cobo.com/login)。
@@ -15,4 +17,3 @@ description: "了解如何在 Fee Station 进行充币操作，确保您的资�
 <img src="/cn/images/fee-station/2.png" className="screenshot_full_screen"/>
 5. 在弹出的窗口中，点击<img src="/cn/images/fee-station/copy.svg" className="icon"></img>以复制充值地址，或使用钱包扫描二维码。
 - 如果您希望从其他在 Cobo Portal 创建的钱包转账到 Fee Station，请点击**从其他钱包充值**，然后按照[该文档](/cn/portal/transfers/introduction)中的指示完成转账操作。
-

--- a/en/portal/fee-station/deposit.mdx
+++ b/en/portal/fee-station/deposit.mdx
@@ -5,6 +5,8 @@ lang: "en"
 description: "Learn how to deposit assets into Fee Station for automatic payment of transaction fees on Cobo Portal."
 ---
 
+<Info>This page covers deposits into the Fee Station for Cobo Custody, which is used to prepay transaction fees and Cobo bill payments for MPC Wallets (Organization-Controlled) and Web3 Wallets on Cobo Portal. If you use Cobo Payments, go to [Fee Management](https://www.cobo.com/payments/en/guides/fee-management) to fund your Payments fee balance instead.</Info>
+
 <Note>You can deposit into Fee Station for automatic payment for transaction fees. Please note that this currently applies only to EVM and TRON transactions initiated from MPC Wallets (Organization-Controlled) and Custodial Wallets (Web3 Wallets) on the Cobo Portal web console.</Note>
 
 1. Log into [Cobo Portal](https://portal.cobo.com/login).
@@ -15,5 +17,4 @@ description: "Learn how to deposit assets into Fee Station for automatic payment
 <img src="/en/images/fee-station/2.png" className="screenshot_full_screen"/>
 5. In the pop-up window, click <img src="/en/images/fee-station/copy.svg" className="icon"></img> to copy the deposit address or scan the QR code with your wallet.
 - If you want to make a transfer from other wallets created on Cobo Portal, click **Deposit from other wallets**. Then, follow the instructions [here](/en/portal/transfers/introduction) to complete the transfer.
-
 


### PR DESCRIPTION
## 意图

依据用户内联反馈《Payments 侧 Fee Management 文档重构计划》及“KB 2026-07-22 Fee Station 专项问题分析”，明确 Cobo Custody Fee Station 与 Cobo Payments Fee Management 的产品边界，避免 Payments 用户按 Custody 的充值说明操作。本 PR 先修正 Custody 中英文充值页；Payments 文档重构和 OpenAPI 源定义修正分别由对应仓库的后续 PR 承载。

## 变更摘要

- `en/portal/fee-station/deposit.mdx`：增加适用范围提示，说明本页仅适用于 Cobo Custody Fee Station，并将 Payments 用户引导至英文 Fee Management 指南。
- `cn/portal/fee-station/deposit.mdx`：同步增加中文适用范围提示及 Payments Fee Management 指南入口。

## 关联 PR

- `payments-manual` 中的 Billing、Fee Management、套餐选择、对账等改动将在后续步骤单独创建 PR，并以评论形式回链本 PR。
- `developer-site-waas2` 中 `estimate_fee.yaml` 的源定义修正将在后续步骤单独创建 api-spec PR，并以评论形式回链本 PR；本次未生成可同步至当前仓库的 `dev_openapi.yaml` 变更。

## 需要在其他仓库改动

- `payments-manual`：完成 `payments/en/guides/` 与 `payments/cn/guides/` 下 Fee Management 术语、计费生命周期、费用模式、套餐选择、对账、报告及导航的配套改动。
- `developer-site-waas2`：修正 `components/schemas/payments/estimate_fee.yaml` 中共享 `token_id` 与 `amount` 的描述和示例，并完成 OpenAPI 校验与同步。

## 代码证据

- `custody-2.0-website/src/interfaces/organization.ts:113`：`EFeeStationPreferenceValue` 定义 `NO_USE`、`USE` 和 `ALWAYS_USE`，证明 Custody 的 Gas 代付策略可配置。
- `custody-2.0-website/src/interfaces/organization.ts:120`：`EFeeStationUsage` 包含 `Bill`、`TransactionFee`、`CommissionFee`、`CoboServiceFee` 和 `PayForU`，证明 Custody Fee Station 承载多类 Custody 费用。
- `custody-2.0-website/src/locales/zh-CN/organization.ts:12`：Custody Portal 使用“充值至 Fee Station”作为充值入口文案，支撑本页继续使用 Custody Fee Station 名称。
- `custody-2.0-website/src/locales/zh-CN/organization.ts:114`：Custody UI 描述从不使用、钱包余额不足时使用及始终使用 Fee Station 三种模式，支撑将其与 Payments Fee Management 区分。
- `custody-2.0-website/src/pages/Payment/components/FeeStation/index.tsx:1`：Custody Portal 调用 Fee Station 概览、支付及账单支付服务，证明本页属于 Custody Fee Station 操作路径。

## ⚠️ 待确认事项

- **待人工确认**：`payments-manual` 的套餐订阅/月最低消费需核实计费任务、抵扣范围、差额公式、账本类型及可公开边界。
- **待人工确认**：`payments-manual` 的 Fee Management 余额退回需核实是否支持自助提取、获批的退款入口、审批流程及可承诺时效。
- **待人工确认**：`payments-manual` 的预付模式需核实逐笔扣费账本、月末最低消费任务、抵扣公式及边界情况。
- **待人工确认**：`payments-manual` 的 Payout 手续费预扣模式需核实适用商户/版本、预扣时点、失败释放及退款冲正行为。
- **待人工确认**：`payments-manual` 的旧版欠费模式需核实商户识别开关、欠款抵扣优先级、充值后补扣任务及迁移范围。
- **待人工确认**：`payments-manual` 的欠费冻结与恢复需核实逾期阈值、受影响 API/产品及自动或人工解冻流程。
- **待人工确认**：`payments-manual` 的 dev 与生产环境差异需核实费率、真实扣费、资产、账本及报告行为，不能默认 dev 免费或仅模拟。
- **待人工确认**：`payments-manual` 的 Starter/Enterprise 边界需核实计划资格、功能开关、合同价适用条件及允许公开的阈值。
- **待人工确认**：`payments-manual` 的 Billing 与 Packages 去重需核实费率权威来源、页面生成配置和 canonical 链接。
- **待人工确认**：`payments-manual` 新页面的导航位置及当前 Portal UI 路径需与线上界面核对，并按已验证 UI 补充截图占位。
- **待人工确认**：规划评审仅批准并完成本 PR 的 Custody 中英文边界提示；其余 Payments 文档改动仍是待产品核实并在独立仓库实现的草稿范围。
