### PR TITLE
docs: 完善全托管转账手续费说明

### DIFF
--- a/cn/portal/transfers/from-asset-wallets.mdx
+++ b/cn/portal/transfers/from-asset-wallets.mdx
@@ -38,16 +38,22 @@ import MySnippet from '/snippets/transfer-category-and-description-cn.mdx';
 
     <Info>如果您使用 WaaS 2.0 API，可以使用 [Check Cobo Loop Transfers](https://www.cobo.com/developers/v2/api-references/transactions/check-loop-transfers) 操作来确定交易是否可以作为 Cobo Loop 转账执行。或者直接调用 [Transfer token](https://www.cobo.com/developers/v2/api-references/transactions/transfer-token) 操作，强制将交易作为 Cobo Loop 转账执行。</Info>
 6. 输入转账金额。
-7. 查看交易手续费。该费用是固定的，无法修改。
+7. 查看交易手续费。
 
-    交易手续费包含以下三个部分：
-    - **归集 Gas 费**：当您存入非原生代币（例如 ETH 上的 USDT）时，Cobo 会向您的充币地址预先充值原生代币（例如 ETH）作为 Gas，以确保后续提币操作的顺利进行。此费用构成为：当前代币余额的归集费 x（提币金额/当前代币余额）% ，并按实时链上 Gas 价格计算。
-    - **合规费**：涵盖充币和提币的 KYT/AML 服务费，以及 Cobo 的合规调查费用。此费用构成为：当前代币余额的充币合规费 x（提币金额/当前代币余额）% + 提币合规费。
-    - **提币 Gas 费**：此费用按实时链上 Gas 价格计算。
-   
-   手续费将从您在第3步中选择的源钱包扣除，您需要确保源钱包中已开通相应的代币且有足够的余额支付。
+    交易手续费包含以下三个组成部分：
+    - **归集费用（扫集费用）**：转出前对资金进行归集（扫集）所分摊的成本。
+    - **合规费用（AML/KYT）**：一项独立的费用组成部分，涵盖充币和提币的 KYT/AML 筛查，以及 Cobo 的合规调查费用。
+    - **链上费用（Gas 费）**：将您的交易纳入区块链所需的网络费用。显示金额为预估值。该预估值取决于适用链的手续费模型、交易复杂度、您选择的速度档位，以及当前网络状况。
 
-    <img src="/cn/images/transfers/fee.png" className="screenshot_modal"/>
+    手续费将从您在第 3 步中选择的源钱包扣除，请确保源钱包中已开通相应的代币且有足够余额支付该费用。
+
+    显示的链上（Gas）费用预估值反映某一时刻的网络状况。可用的手续费控制方式取决于所在链及其手续费模型。对于采用 EVM 或 UTXO 手续费模型的链，您可以为转账自定义网络参数。由于网络状况和交易复杂度可能发生变化，请在提交转账前刷新或重新预估链上（Gas）费用。
+
+    <Info>
+    手续费预估通过 [Estimate transaction fee](https://www.cobo.com/developers/v2/guides/transactions/estimate-fees) 操作生成，该操作需要 `TRANSACTION:ESTIMATE_FEE` 权限。该操作根据链的手续费模型返回 `slow`、`recommended`、`fast` 三档预估值，且仅覆盖链上（Gas）费用，不包含归集费用或合规费用。由于该结果为某一时刻的预估值，请在提交转账前重新获取。
+    </Info>
+
+    <img src="/cn/images/transfers/fee.png" className="screenshot_modal" alt="交易手续费明细截图"/>
 
 8. <MySnippet />
 9. 点击**提交**。
@@ -60,4 +66,3 @@ import MySnippet from '/snippets/transfer-category-and-description-cn.mdx';
 
 如果您使用 WaaS 2.0 API，可以调用 [Get transaction information](https://www.cobo.com/developers/v2/api-references/transactions/get-transaction-information) 或 [List all transactions operations](https://www.cobo.com/developers/v2/api-references/transactions/list-all-transactions) 并检查响应中的`is_loop`属性。
 此外，您还可以使用 [Cobo Loop Explorer](https://loop.top/) 通过 Loop ID（即该交易的交易哈希）来追踪 Cobo Loop 转账的状态。
-

--- a/en/portal/transfers/from-asset-wallets.mdx
+++ b/en/portal/transfers/from-asset-wallets.mdx
@@ -41,16 +41,22 @@ For more detailed information about the discounts, please contact our sales team
     <Info>If you are using the WaaS 2.0 API, you can use the [Check Cobo Loop transfers](https://www.cobo.com/developers/v2/api-references/transactions/check-loop-transfers) operation to determine if a transaction can be executed as a Cobo Loop transfer. Or directly call the [Transfer token](https://www.cobo.com/developers/v2/api-references/transactions/transfer-token) operation to enforce a transaction as a Cobo Loop transfer.</Info>
 
 6. Enter the transfer amount.
-7. Review the transaction cost. You are unable to modify or customize this fee. 
+7. Review the transaction cost.
 
-    Transaction fees consist of the following three aspects:
-        - Sweeping gas fee: When you deposit a non-native token (e.g., USDT on Ethereum), Cobo pre-charges your deposit address with the native token (e.g., ETH) as gas to ensure future withdrawals can be processed smoothly. This fee is calculated as: Sweeping fee of current token balance × (Withdrawal amount / Current token balance)%, based on the real-time on-chain gas price.
-        - Compliance fee: Covers KYT/AML service fees for deposits and withdrawals, as well as Cobo’s compliance investigation costs. This fee is calculated as: Deposit compliance fee of current token balance × (Withdrawal amount / Current token balance)% + Withdrawal compliance fee.
-        - Withdrawal gas fee: Calculated based on the real-time on-chain gas price.
+    Transaction fees consist of the following three components:
+    - **Consolidation (sweeping) fee**: The allocated cost of consolidating, or sweeping, funds before an outbound transfer.
+    - **Compliance fee (AML/KYT)**: A separate fee component that covers KYT/AML screening for deposits and withdrawals, as well as Cobo's compliance investigation costs.
+    - **On-chain (Gas) fee**: The network fee required to include your transaction on the blockchain. The displayed amount is an estimate. The estimate depends on the applicable chain's fee model, the complexity of the transaction, the speed tier you select, and current network conditions.
 
-The fee amount will be deducted from the source wallet that you selected in step 3. Please ensure that the source wallet has the required token enabled and sufficient balance for the fee payment.
+    The fee amount will be deducted from the source wallet that you selected in step 3. Please ensure that the source wallet has the required token enabled and sufficient balance for the fee payment.
 
-    <img src="/en/images/transfers/fee.png" className="screenshot_modal"/>
+    The displayed on-chain (gas) fee estimate reflects a point in time. Available fee controls depend on the chain and its fee model. For chains that use the EVM or UTXO fee model, you can customize network parameters for the transfer. Because network conditions and transaction complexity can change, refresh or re-estimate the on-chain (gas) fee shortly before you submit the transfer.
+
+    <Info>
+    Fee estimates are produced by the [Estimate transaction fee](https://www.cobo.com/developers/v2/guides/transactions/estimate-fees) operation, which requires the `TRANSACTION:ESTIMATE_FEE` permission. It returns `slow`, `recommended`, and `fast` estimates based on the chain's fee model, and covers only the on-chain (gas) fee — not the consolidation or compliance fee. Because it produces a point-in-time estimate, refresh it before you submit the transfer.
+    </Info>
+
+    <img src="/en/images/transfers/fee.png" className="screenshot_modal" alt="Screenshot of the transaction fee breakdown"/>
 
 8. <MySnippet />
 9. Click **Submit**.


### PR DESCRIPTION
## 关联来源
- https://pha.1cobo.com/T97307

## 意图
完善全托管资产钱包转账手续费说明，清晰区分归集费用、合规费用与链上（Gas）费用，并说明链上费用会随网络状况和交易复杂度变化。同步修正中英文页面中“费用固定且不可修改”的表述，并补充 `Estimate transaction fee` 的自助预估入口、权限和适用范围。

## 变更摘要
- `en/portal/transfers/from-asset-wallets.mdx`：重写步骤 7 的手续费说明，区分三类费用，补充链上费用预估的影响因素、刷新建议及 `Estimate transaction fee` 操作链接。
- `cn/portal/transfers/from-asset-wallets.mdx`：以等价中文术语同步英文页面的手续费组成、动态预估行为和 API 使用说明。

## 代码证据
- `custody/partition_fee/models/inoutbound_fee.py:9-24`：后端费用模型将客户费用拆分为归集/扫集成本、合规成本和出站链上成本，支持三类费用的独立表述。
- `custody/waas2/inoutbound_fee/processors/outbound_detail.py:39-77`：提币费用明细分别记录 `outbound_chain`、`outbound_compliance`、`part_inbound_fee` 和 `part_inbound_fee_detail`。
- `custody/waas2/transactions/dev/views/estimate_fee.py:23-44`：公开 `Estimate transaction fee` POST 操作需要 `TRANSACTION:ESTIMATE_FEE` 权限，并将网络拥堵和交易复杂度列为预估因素。
- `custody/waas2/transactions/dev/bo/estimate_fee.py:128-171`：预估响应支持 EVM EIP-1559、EVM legacy、UTXO、SOL 和 FIL 模型，并按 `token_id` 返回 `slow`、`recommended`、`fast` 档位。
- `custody/waas2/inoutbound_fee/views/estimate.py:26-45`、`custody/waas2/inoutbound_fee/urls_integration.py:31-35`：合作方集成预估路径与面向客户的公开交易手续费 API 不同，因此文档未将其作为自助入口。
- `custody-2.0-website/src/interfaces/transfer.ts:180-204`、`custody-2.0-website/src/services/transfer/index.ts:293-301`：Portal 转账前预估展示链费模型和手续费代币信息，但不逐项展示归集或合规费用，且其内部接口不是手册应链接的公开 WaaS 2.0 API。
- `custody-2.0-website/src/pages/Transfer/TransactionCost/EVMModel/index.tsx:313-354`、`custody-2.0-website/src/pages/Transfer/TransactionCost/UTXOModel/index.tsx:183-222`：Portal 的 EVM 和 UTXO 流程允许自定义网络手续费参数，证明原“费用不可修改”的表述不准确。
- `custody-2.0-website/src/locales/en-US/transfer.ts:96`、`custody-2.0-website/src/locales/en-US/transfer.ts:99-101`：Portal 给出 EIP-1559、Layer 2、SOL 和 FIL 的链上手续费计算说明，支持按链模型描述预估逻辑。
- `developer-site-waas2/v2/cobo_waas2_openapi_spec/paths/transactions/estimate_fee.yaml:7-13`：规范确认预估受网络拥堵和交易复杂度影响，结果是短时有效的时点预估，并指向规范化指南。
- `developer-site-waas2/v2/cobo_waas2_openapi_spec/components/schemas/transactions/estimate_fee/estimate_fee.yaml:1-8`：公开预估请求通过 discriminator 支持 `Transfer` 和 `ContractCall` 类型。
- `developer-site-waas2/v2/cobo_waas2_openapi_spec/components/schemas/transactions/fees/estimated_fee.yaml:1-16`：公开预估响应仅包含链上手续费模型，不包含归集或合规费用。

## ⚠️ 待确认事项
- **待人工确认（EN/CN）**：已检索费用拆分模型、出站明细处理和公开预估实现，但尚不能确认链上费用在交易处理中的确切计费时点、最终扣费是否会与最后显示的预估不同、客户可见响应中区分预估与最终扣费的字段，以及现有 Portal 信息以外的完整逐链公式；需由全托管交易与计费负责人核实。（对应 `en/portal/transfers/from-asset-wallets.mdx:49`、`cn/portal/transfers/from-asset-wallets.mdx:46`）
- **待人工确认（EN/CN）**：已检索 `part_inbound_fee` 模型及出站费用明细，但尚不能确认归集费适用的链和资产、触发归集的阈值或事件、分摊公式，以及充币地址 Gas 预充值是否应保留为单独命名的 Sweeping gas fee；需由归集流程与计费负责人核实。（对应 `en/portal/transfers/from-asset-wallets.mdx:47`、`cn/portal/transfers/from-asset-wallets.mdx:44`）
- **待人工确认（EN/CN）**：已检索合规费用模型及出站明细处理，但尚不能确认费用是普遍收取还是仅在特定 AML/KYT 风险或人工审核条件下收取、具体配置金额与充提分摊公式，以及客户可见报价或交易响应中的明细位置；需由合规路由与计费负责人核实。（对应 `en/portal/transfers/from-asset-wallets.mdx:48`、`cn/portal/transfers/from-asset-wallets.mdx:45`）
- **待人工确认（EN/CN）**：已检索链费来源、公开预估规范及 EVM/UTXO Portal 控件，但尚不能确认缓存刷新或报价过期的具体时长、拥堵阈值或费率来源、最终扣费与最后预估的关系，以及 EVM/UTXO 之外模型的自定义支持；需由链费服务与 Portal 负责人核实。（对应 `en/portal/transfers/from-asset-wallets.mdx:53`、`cn/portal/transfers/from-asset-wallets.mdx:50`）
- **待人工确认（EN/CN）**：已检索公开操作的权限、请求类型和响应模型，但尚不能确认该端点对 Full Custody Asset Wallet 的显式钱包类型准入、具体预估有效期、最终费用差异及归集/合规最终费用字段；中文规范指南 URL 也尚未确认，需由 WaaS 2.0 API 与文档负责人核实。（对应 `en/portal/transfers/from-asset-wallets.mdx:56`、`cn/portal/transfers/from-asset-wallets.mdx:53`）
