### PR TITLE
docs: 补充 Portal 最低提币金额说明

### DIFF
--- a/cn/portal/transfers/withdrawal-prerequisites.mdx
+++ b/cn/portal/transfers/withdrawal-prerequisites.mdx
@@ -18,6 +18,10 @@ description: "了解在 Cobo Portal 中从钱包发起提币之前必须满足�
 - 请确保钱包持有足够的原生 gas 代币（例如，EVM 网络上的 ETH 或 TRON 上的 TRX），或已启用 [Fee Station](/cn/portal/fee-station/introduction) 来支付 gas 费。
 - 您要提取的金额必须可用作可用余额，且未被另一笔进行中的交易锁定。详情请参阅[余额锁定](/cn/portal/transfers/introduction#balance-locking)。
 
+## 最低提币金额
+
+每个代币和网络均有最低提币金额。如果您提交的外部提币金额低于所选网络的最低金额，Cobo 将在交易广播至链上之前于验证阶段拒绝该请求。由于交易未被广播，您无需支付网络 gas 费或 Cobo 服务费。
+
 ## 相关主题
 
 - [转账简介](/cn/portal/transfers/introduction)

--- a/en/portal/transfers/withdrawal-prerequisites.mdx
+++ b/en/portal/transfers/withdrawal-prerequisites.mdx
@@ -18,6 +18,10 @@ The wallet must have enough balance to cover both the withdrawal amount and the 
 - Make sure the wallet holds enough of the native gas token (for example, ETH on EVM networks or TRX on TRON), or that [Fee Station](/en/portal/fee-station/introduction) is enabled to pay the gas fee.
 - The amount you want to withdraw must be available as spendable balance and not locked by another in-flight transaction. For details, see [Balance locking](/en/portal/transfers/introduction#balance-locking).
 
+## Minimum withdrawal amount
+
+Each token and network has a minimum withdrawal amount. If the amount you enter for an external withdrawal falls below the minimum for the selected network, Cobo rejects the request during validation before the transaction is broadcast on-chain. Because no transaction is broadcast, you are not charged a network gas fee or a Cobo service fee.
+
 ## Related topics
 
 - [Introduction to Transfer](/en/portal/transfers/introduction)


### PR DESCRIPTION
## 意图

本次变更补充 Portal 提币指南中关于最低提币金额的说明。原反馈指出，当用户发起的外部提币金额低于目标链网络最小限额（dust threshold）时，文档没有明确说明系统行为。根据代码证据，Cobo 会在交易广播到链上之前的验证阶段拒绝该请求，因此不会收取网络 gas 费或 Cobo 服务费。

## 变更摘要

- `en/portal/transfers/withdrawal-prerequisites.mdx`：在 `Sufficient balance` 后新增 `Minimum withdrawal amount` 小节，说明外部提币低于所选网络最低金额时会在广播前被拒绝，且不收取网络 gas 费或 Cobo 服务费。
- `cn/portal/transfers/withdrawal-prerequisites.mdx`：在 `充足的余额` 后新增对应的 `最低提币金额` 小节，与英文页保持语义一致，补充最低提币金额、广播前拒绝和不收费的说明。

## 代码证据

- `custody/waas2/transfer/managers/custodial/asset/utils.py:87`：Portal custodial pre-transfer validation 会先调用 `_check_amount`，然后才进入后续 blockchain pre-send 步骤。
- `custody/waas2/transfer/managers/custodial/asset/utils.py:187`：Portal custodial transfer validation 会先调用 `_check_amount`，之后才进入从第 188 行开始的 fee lookup/deduction 逻辑。
- `custody/waas2/transfer/managers/custodial/asset/utils.py:353`：`_check_amount` 仅在没有目标 custody wallet 的外部提币场景下应用 dust-threshold 检查。
- `custody/waas2/transfer/managers/custodial/asset/utils.py:357`：外部提币金额低于 `token_info.dust_threshold` 时，代码会在继续处理前抛出 `PortalTransferException`。
- `custody/waas2/base/exceptions/transfer.py:18`：`PortalTransferException.ERROR_BELOW_DUST_THRESHOLD` 的错误码为 `30010`。
- `custody/waas2/base/exceptions/transfer.py:68`：错误码 `30010` 的用户可见消息为 `The minimum withdrawal amount for Custodial Wallets is {abs_amount} {token_symbol}.`。
- `custody/custody/custody/managers/requests/withdraw/base.py:205`：legacy external withdrawal validation 同样会拒绝低于 `coin_info.dust_threshold` 的金额。
- `custody/custody/custody/managers/requests/withdraw/base.py:209`：legacy withdrawal path 会抛出 `ERROR_TRANSACTION_BELOW_DUST`，消息为 `Coin {asset_coin}'s tx amount below {dust} not supported`。
- `custody/custody/custody/managers/requests/withdraw/base.py:233`：legacy blockchain `pre_send` 位于单独的后续方法中，支持 dust exception 发生在广播前。
- `custody/custody/web3/controllers/request_builder/base_transaction_request_builder.py:1055`：Web3 request builder 也会在金额低于 `token_info.dust_threshold` 时以 `ERROR_TRANSACTION_BELOW_DUST` 拒绝请求。

## ⚠️ 待确认事项

- **待人工确认（EN/CN）**：已检索 Portal custodial validation、legacy withdrawal validation 和 Web3 request builder 的 dust-threshold 拒绝逻辑，代码证据支持"广播前拒绝且未进入 fee lookup/deduction"的文档结论；但错误码 `30010` 触发后 Portal UI 的具体展示方式和最终交易状态未在本次变更中声明，需要 custody 产品或前端实现负责人确认。（对应 `en/portal/transfers/withdrawal-prerequisites.mdx:21`、`cn/portal/transfers/withdrawal-prerequisites.mdx:21`）

---
[TEST] 这是一次验证性测试 run（测试 doc-writing-core pipeline 在只涉及 product-manual 单仓库时能否跑通），不是真实用户反馈驱动的改动，内容质量可参考但不代表已排期的需求。
