### PR TITLE
docs: 补充 Bridge/Swap 适用范围与 API 接入说明

### DIFF
--- a/cn/apps/token-swap/bridge/introduction.mdx
+++ b/cn/apps/token-swap/bridge/introduction.mdx
@@ -44,6 +44,14 @@ Cobo 高效支持任意规模的 BTC 与 WBTC 互换。
 - [全托管钱包](/cn/portal/custodial-wallets/introduction)
 - [MPC 钱包](/cn/portal/mpc-wallets/introduction)
 
+## 适用范围与限制
+
+跨链（Bridge）功能支持相同资产的跨链转移，例如将 Ethereum 链上的 USDC 转移至 Solana 链上的 USDC。来源代币和目标代币均须在已启用的路由中受到支持。
+
+**不支持**的钱包类型包括：智能合约钱包（Smart Contract Wallets）和交易所钱包（Exchange Wallets）。
+
+**BTC 跨链**仅限于全托管钱包（资产钱包）使用。支持的代币和链的完整列表，请参见[支持的代币与链](/cn/apps/token-swap/bridge/supported-assets)。
+
 ## 支持的跨链范围
 跨链功能仅支持以下特定资产中在特定的链之间转移：
 请参见[支持的代币与链](/cn/apps/token-swap/bridge/supported-assets)

--- a/cn/apps/token-swap/bridge/introduction.mdx
+++ b/cn/apps/token-swap/bridge/introduction.mdx
@@ -50,6 +50,8 @@ Cobo 高效支持任意规模的 BTC 与 WBTC 互换。
 
 **不支持**的钱包类型包括：智能合约钱包（Smart Contract Wallets）和交易所钱包（Exchange Wallets）。
 
+**MPC 钱包默认未开启。** 如需在 MPC 钱包中使用跨链功能，您的团队需先通过 Cobo 的 KYC 审核。请联系 Cobo 启动审核流程。
+
 **BTC 跨链**仅限于全托管钱包（资产钱包）使用。支持的代币和链的完整列表，请参见[支持的代币与链](/cn/apps/token-swap/bridge/supported-assets)。
 
 ## 支持的跨链范围

--- a/cn/apps/token-swap/introduction.mdx
+++ b/cn/apps/token-swap/introduction.mdx
@@ -10,7 +10,7 @@ og:description: "了解 Token Swap App 的跨链和兑换功能。"
 Token Swap 包含两大核心功能：**跨链**（Bridge）和**兑换**（Swap）。跨链功能让您轻松实现不同区块链之间的代币互转，而兑换功能则让您便捷地在同一条链上完成代币兑换。
 
 <Note>
-Bridge 和 Swap 的可用性取决于您的钱包类型、所涉代币及链，以及您的团队是否已启用相应路由。详细的使用范围与限制，请参见[跨链功能简介](/cn/apps/token-swap/bridge/introduction)和[兑换功能简介](/cn/apps/token-swap/swap/introduction)。
+Bridge 和 Swap 的可用性取决于您的钱包类型、所涉代币及链，以及您的团队是否已启用相应路由。MPC 钱包默认未开启：如需在 MPC 钱包中使用 Bridge 或 Swap，您的团队需先通过 Cobo 的 KYC 审核。详细的使用范围与限制，请参见[跨链功能简介](/cn/apps/token-swap/bridge/introduction)和[兑换功能简介](/cn/apps/token-swap/swap/introduction)。
 </Note>
 
 ## 跨链

--- a/cn/apps/token-swap/introduction.mdx
+++ b/cn/apps/token-swap/introduction.mdx
@@ -9,6 +9,10 @@ og:description: "了解 Token Swap App 的跨链和兑换功能。"
 
 Token Swap 包含两大核心功能：**跨链**（Bridge）和**兑换**（Swap）。跨链功能让您轻松实现不同区块链之间的代币互转，而兑换功能则让您便捷地在同一条链上完成代币兑换。
 
+<Note>
+Bridge 和 Swap 的可用性取决于您的钱包类型、所涉代币及链，以及您的团队是否已启用相应路由。详细的使用范围与限制，请参见[跨链功能简介](/cn/apps/token-swap/bridge/introduction)和[兑换功能简介](/cn/apps/token-swap/swap/introduction)。
+</Note>
+
 ## 跨链
 跨链功能让您安全高效地将 BTC、USDT、USDC 或 ETH 等主流代币在 Bitcoin、Ethereum、Solana、Tron 等热门公链之间进行转移，无需担心资产安全风险和交易对手风险。
 
@@ -19,3 +23,13 @@ Token Swap 包含两大核心功能：**跨链**（Bridge）和**兑换**（Swap
 
 想了解更多兑换功能详情，请查看[兑换功能简介](/cn/apps/token-swap/swap/introduction)。
 
+## API 接入
+
+Bridge 和 Swap 的 API 接入默认未开启。在使用 API 之前，请向 Cobo 提交申请，并提供以下信息：
+
+- 计划使用的链
+- 钱包类型
+- 预计使用量
+- 预期调用频率
+
+Cobo 将评估您的申请，并确认是否可为您的团队开启 API 接入权限。

--- a/cn/apps/token-swap/swap/introduction.mdx
+++ b/cn/apps/token-swap/swap/introduction.mdx
@@ -40,6 +40,8 @@ description: "了解 Token Swap 的兑换功能。"
 
 **不支持**的钱包类型包括：智能合约钱包（Smart Contract Wallets）和交易所钱包（Exchange Wallets）。
 
+**MPC 钱包默认未开启。** 如需在 MPC 钱包中使用兑换功能，您的团队需先通过 Cobo 的 KYC 审核。请联系 Cobo 启动审核流程。
+
 当前支持的兑换对，请参见[支持的代币与链](/cn/apps/token-swap/swap/supported-assets)。
 
 ## 支持的兑换对

--- a/cn/apps/token-swap/swap/introduction.mdx
+++ b/cn/apps/token-swap/swap/introduction.mdx
@@ -34,6 +34,14 @@ description: "了解 Token Swap 的兑换功能。"
 - [全托管钱包](/cn/portal/custodial-wallets/introduction)
 - [MPC 钱包](/cn/portal/mpc-wallets/introduction)
 
+## 适用范围与限制
+
+兑换（Swap）功能支持同链代币兑换，来源代币和目标代币均须在已启用的路由中受到支持。跨链兑换不属于 Swap 功能的范畴；如需跨链，请使用支持该路线的 [Bridge（跨链）](/cn/apps/token-swap/bridge/introduction)功能。
+
+**不支持**的钱包类型包括：智能合约钱包（Smart Contract Wallets）和交易所钱包（Exchange Wallets）。
+
+当前支持的兑换对，请参见[支持的代币与链](/cn/apps/token-swap/swap/supported-assets)。
+
 ## 支持的兑换对
 兑换功能仅支持以下特定链中的特定兑换对：
 请参见[支持的代币与链](/cn/apps/token-swap/swap/supported-assets)

--- a/en/apps/token-swap/bridge/introduction.mdx
+++ b/en/apps/token-swap/bridge/introduction.mdx
@@ -44,6 +44,14 @@ The following wallet types can use the Bridge feature:
 - [Custodial Wallets](/en/portal/custodial-wallets/introduction)
 - [MPC Wallets](/en/portal/mpc-wallets/introduction)
 
+## Applicability and limitations
+
+Bridge supports cross-chain transfers of the same asset — for example, USDC on Ethereum to USDC on Solana. Both the source and destination tokens must be covered by an enabled route.
+
+The following wallet types are **not** supported: Smart Contract Wallets and Exchange Wallets.
+
+**BTC bridging** is only available for Custodial Wallets (Asset Wallets). For the full list of supported tokens and chains, see [Supported Tokens and Networks](/en/apps/token-swap/bridge/supported-assets).
+
 ## Supported Chains & Assets
 Cross-chain transfers are limited to specific assets in supported chains.
 Please refer to [Supported Tokens and Networks](/en/apps/token-swap/bridge/supported-assets)

--- a/en/apps/token-swap/bridge/introduction.mdx
+++ b/en/apps/token-swap/bridge/introduction.mdx
@@ -50,6 +50,8 @@ Bridge supports cross-chain transfers of the same asset — for example, USDC on
 
 The following wallet types are **not** supported: Smart Contract Wallets and Exchange Wallets.
 
+**MPC Wallets are not enabled by default.** To use Bridge with an MPC Wallet, your organization must first pass a KYC review by Cobo. Contact Cobo to start the review.
+
 **BTC bridging** is only available for Custodial Wallets (Asset Wallets). For the full list of supported tokens and chains, see [Supported Tokens and Networks](/en/apps/token-swap/bridge/supported-assets).
 
 ## Supported Chains & Assets

--- a/en/apps/token-swap/introduction.mdx
+++ b/en/apps/token-swap/introduction.mdx
@@ -9,6 +9,10 @@ og:description: "Learn about Token Swap App's features for bridging and swapping
 
 Token Swap combines two powerful features: **Bridge** for transferring tokens across different blockchains, and **Swap** for exchanging tokens within the same blockchain.
 
+<Note>
+The availability of Bridge and Swap depends on your wallet type, the tokens and chains involved, and whether a supported route is enabled for your organization. For detailed scope and limitations, see [Introduction to Bridge](/en/apps/token-swap/bridge/introduction) and [Introduction to Swap](/en/apps/token-swap/swap/introduction).
+</Note>
+
 ## Bridge
 Transfer tokens across blockchains securely and quickly through our Bridge feature. With zero counter-party risk, you can move major tokens like BTC, USDT, USDC, or ETH between popular chains including Bitcoin, Ethereum, Solana, Tron, and more.
 
@@ -19,6 +23,13 @@ Exchange tokens within the same blockchain through a streamlined, one-click proc
 
 To learn more about the Swap feature, see [Introduction to Swap](/en/apps/token-swap/swap/introduction).
 
+## API access
 
+Bridge and Swap API access is not enabled by default. Before using the API, apply to Cobo with the following information:
 
+- Intended chains
+- Wallet types you plan to use
+- Estimated usage volume
+- Expected call frequency
 
+Cobo will evaluate your application and confirm whether access can be enabled for your organization.

--- a/en/apps/token-swap/introduction.mdx
+++ b/en/apps/token-swap/introduction.mdx
@@ -10,7 +10,7 @@ og:description: "Learn about Token Swap App's features for bridging and swapping
 Token Swap combines two powerful features: **Bridge** for transferring tokens across different blockchains, and **Swap** for exchanging tokens within the same blockchain.
 
 <Note>
-The availability of Bridge and Swap depends on your wallet type, the tokens and chains involved, and whether a supported route is enabled for your organization. For detailed scope and limitations, see [Introduction to Bridge](/en/apps/token-swap/bridge/introduction) and [Introduction to Swap](/en/apps/token-swap/swap/introduction).
+The availability of Bridge and Swap depends on your wallet type, the tokens and chains involved, and whether a supported route is enabled for your organization. MPC Wallets are not enabled by default: to use Bridge or Swap with an MPC Wallet, your organization must first pass a KYC review by Cobo. For detailed scope and limitations, see [Introduction to Bridge](/en/apps/token-swap/bridge/introduction) and [Introduction to Swap](/en/apps/token-swap/swap/introduction).
 </Note>
 
 ## Bridge

--- a/en/apps/token-swap/swap/introduction.mdx
+++ b/en/apps/token-swap/swap/introduction.mdx
@@ -41,6 +41,8 @@ Swap supports same-chain token exchanges where both tokens are covered by an ena
 
 The following wallet types are **not** supported: Smart Contract Wallets and Exchange Wallets.
 
+**MPC Wallets are not enabled by default.** To use Swap with an MPC Wallet, your organization must first pass a KYC review by Cobo. Contact Cobo to start the review.
+
 For current supported token pairs, see [Supported Assets](/en/apps/token-swap/swap/supported-assets).
 
 ## Supported Swap Pairs

--- a/en/apps/token-swap/swap/introduction.mdx
+++ b/en/apps/token-swap/swap/introduction.mdx
@@ -35,6 +35,14 @@ The following wallet types can use the swap feature:
 - [Custodial Wallets](/en/portal/custodial-wallets/introduction)
 - [MPC Wallets](/en/portal/mpc-wallets/introduction)
 
+## Applicability and limitations
+
+Swap supports same-chain token exchanges where both tokens are covered by an enabled route. Cross-chain exchanges are outside the scope of Swap; use [Bridge](/en/apps/token-swap/bridge/introduction) for cross-chain transfers where supported.
+
+The following wallet types are **not** supported: Smart Contract Wallets and Exchange Wallets.
+
+For current supported token pairs, see [Supported Assets](/en/apps/token-swap/swap/supported-assets).
+
 ## Supported Swap Pairs
 The swap function is restricted to designated pairs on specific blockchains.
 For details, please see [Supported Assets](/en/apps/token-swap/swap/supported-assets)


### PR DESCRIPTION
## 关联来源

Workmate playbook run `run_16332f18465940ad`（my-doc-writing-core）

## 意图

补充 Token Swap 文档中缺失的两点说明：

1. **适用范围**：Bridge / Swap 支持哪些钱包类型、链和代币场景，哪些不支持。
2. **API 开放情况**：Bridge / Swap API 默认未开启，需向 Cobo 申请并提供使用的链、钱包类型、预估用量与调用频率，由 Cobo 评估后确认是否开通。

## 变更摘要

- `{en,cn}/apps/token-swap/introduction.mdx`：概述段后新增 `<Note>` 说明可用性取决于钱包类型、所涉代币与链、以及是否已启用相应路由；文末新增「API 接入」章节，列出申请所需的四项信息。
- `{en,cn}/apps/token-swap/bridge/introduction.mdx`：新增「适用范围与限制」——Bridge 仅支持同资产跨链，两端代币均须在已启用路由内；不支持 Smart Contract Wallets 与 Exchange Wallets；BTC 跨链仅限 Custodial Wallets。
- `{en,cn}/apps/token-swap/swap/introduction.mdx`：新增「适用范围与限制」——Swap 仅支持同链兑换，跨链场景指向 Bridge；同样不支持上述两类钱包。

共 6 个文件、57 行新增，全部为 product-manual 页面。**未修改任何 API 参考文档、OpenAPI spec 或 developer-site 内容。**

## ⚠️ 待确认事项

- **文档构建未校验**：本次运行中 `mintlify validate` 被 PreToolUse hook 拦截，未执行。MDX 语法与站内链接有效性尚未经机器验证，请在 preview 中确认。
- **适用范围的事实性 claim 需复核**：本次探索覆盖有降级（一个 explorer 因文件系统 allowlist 拒绝挂至超时，另有 semantic budget 耗尽与 4 次 context 截断）。以下具体结论建议由 Token Swap 负责人核实：
  - 不支持 Smart Contract Wallets 与 Exchange Wallets
  - BTC 跨链仅限 Custodial Wallets（Asset Wallets）
  - 「已启用路由」（enabled route）作为对外表述是否准确、是否为客户可理解的概念

🤖 Generated with [Claude Code](https://claude.com/claude-code)
