### PR TITLE
docs: 明确付费套餐升级边界

### DIFF
--- a/cn/portal/bills-and-payments/introduction.mdx
+++ b/cn/portal/bills-and-payments/introduction.mdx
@@ -11,7 +11,7 @@ description: "了解 Cobo Portal 的账单和支付功能，掌握付费套餐�
 
 套餐方案页面包含以下选项卡：
 
-- **套餐方案**: 查看和管理当前套餐方案，比较可用方案，并根据需要升级或降级。
+- **套餐方案**: 查看和管理当前套餐方案，比较可用方案。
 - **账单**: 查看账单历史记录，下载发票，并跟踪付款状态。
 - **优惠券**: 查看和管理应用于您账户的促销优惠券或积分。
 
@@ -80,13 +80,13 @@ Cobo 提供多种付费套餐，满足您多样的业务需求。您可在官网
       - 钱包地址数
       - API调用次数
       - 用户成员数
-    - Tips：如果您的项目在起步阶段，可以选择用量较低的套餐，当项目成长后，您可以选择支付少量超量费用，或随时升级到更高等级的套餐。
+    - Tips：如果您的项目在起步阶段，可以选择用量较低的套餐，当项目成长后，您可以选择支付少量超量费用。如需升级至更高等级套餐，请[联系销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。
 
 ## 如何购买
 
-您可以[自主注册，开启14日免费使用](https://www.cobo.com/zh/lp/14-day-free-trial-cobo)，在14天内体验Cobo的强大能力。
-试用过程中及试用结束后，您可以在产品内随时自主升级入门版和标准版套餐。
-如果您需要专业版，则可以[联系我们的销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。
+您可以[自主注册，开启 14 日免费使用](https://www.cobo.com/zh/lp/14-day-free-trial-cobo)，在 14 天内体验 Cobo 的强大能力。
+试用过程中及试用结束后，您可以在产品内自助开通入门版或标准版套餐。已开通付费套餐后，如需切换至更高等级套餐，请[联系销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。
+如果您需要专业版套餐，请[联系我们的销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。
 
 ## 使用项目
 

--- a/cn/portal/bills-and-payments/manage-pricing-plan.mdx
+++ b/cn/portal/bills-and-payments/manage-pricing-plan.mdx
@@ -19,7 +19,7 @@ import PaymentMethods from '/snippets/bills/methods-cn.mdx';
 
 ## 升级付费套餐
 
-如果您想升级付费套餐，请[联系我们的销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。
+如果您的团队已开通入门版或标准版套餐并希望升级至更高级别套餐，请[联系销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。已开通付费套餐的团队不支持在产品内自助升级套餐。
 
 ## 购买用量包
 

--- a/cn/portal/bills-and-payments/purchase-pricing-plan.mdx
+++ b/cn/portal/bills-and-payments/purchase-pricing-plan.mdx
@@ -19,14 +19,21 @@ import PaymentMethods from '/snippets/bills/methods-cn.mdx';
 - 股东或最终受益所有人 (UBO) 信息。
 
 ## 购买入门版或标准版套餐
-购买入门版或标准版套餐使用MPC钱包，无需进行KYC认证。
-请按照以下步骤在 Cobo Portal 上为 MPC 钱包购买入门版或标准版套餐。 
+
+<Note>本文介绍的自助购买流程仅适用于处于免费试用期（包括试用期已结束）或尚未开通任何付费套餐的团队。如果您的团队已开通入门版或标准版套餐并希望切换至更高级别套餐，请[联系销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。</Note>
+
+购买入门版或标准版套餐使用 MPC 钱包，无需进行 KYC 认证。
+请按照以下步骤在 Cobo Portal 上为 MPC 钱包购买入门版或标准版套餐。
 
 1. 登录 [Cobo Portal](https://portal.cobo.com/login)。
 2. 点击右上角的个人头像，选择**套餐方案**。 
 3. 选择 **MPC 钱包**。
-4. 在页面上点击**选择套餐**或**升级**。
+4. 在页面上点击**升级**（处于免费试用期时显示）或**选择套餐**（尚未开通任何套餐时显示）。
 5. 在**选择套餐**对话框中，选择**钱包即服务（WaaS）** 或**财资管理**，然后在您想购买的套餐下点击**开通**。
 6. 在**开通套餐**对话框中，勾选服务协议旁边的复选框，选择一个计费周期，然后点击**支付**。
 7. <PaymentMethods />
+
+## 升级已有付费套餐
+
+如果您的团队已开通入门版或标准版套餐并希望升级至更高级别套餐，请[联系销售团队](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales)。已开通付费套餐的团队不支持在产品内自助升级套餐。
     

--- a/en/portal/bills-and-payments/introduction.mdx
+++ b/en/portal/bills-and-payments/introduction.mdx
@@ -11,7 +11,7 @@ To access Pricing Plans, click your profile avatar in the top-right corner and s
 
 The Pricing Plans page includes the following tabs:
 
-- **Pricing Plans**: View and manage your current pricing plan, compare available plans, and upgrade or downgrade as needed.
+- **Pricing Plans**: View and manage your current pricing plan and compare available plans.
 - **Bills**: View your billing history, download invoices, and track payment status.
 - **Vouchers**: View and manage any promotional vouchers or credits applied to your account.
 
@@ -85,13 +85,13 @@ Each pricing plan offers two distinct usage quota categories designed to cater t
       - Number of Wallet Addresses
       - API Call Quotas
       - Number of Team Members
-    - **Pro Tip**: If your project is in its early stages, start with a lower-tier plan. As your business grows, you can either pay a small overage fee for extra usage or upgrade to a higher tier at any time.
+    - **Pro Tip**: If your project is in its early stages, start with a lower-tier plan. As your business grows, you can pay a small overage fee for extra usage. To upgrade to a higher-tier plan, [contact the sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales).
 
-## How to Start a Freetrial and Upgrade
+## How to start a free trial and purchase a plan
 
-You can sign up on your own to [**start a 14-day free trial**](https://www.cobo.com/lp/14-day-free-trial-cobo) and experience the full power of Cobo. 
+You can sign up on your own to [**start a 14-day free trial**](https://www.cobo.com/lp/14-day-free-trial-cobo) and experience the full power of Cobo.
 
-During or after your trial, you can **self-upgrade to the Starter or Standard plan** directly within the product at any time. 
+During or after your trial, you can purchase a **Starter or Standard plan** directly within the product. Once you are on a paid plan and want to switch to a higher-tier plan, [**contact the sales team**](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales).
 
 For the **Enterprise plan**, please [**contact our sales team**](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) for a custom solution.
 
@@ -110,4 +110,4 @@ Use the **Vouchers** tab to view and manage any promotional vouchers or credits 
 
 Once your free trial expires or when you hit the usage limits of the free trial, you will only be able to view your MPC Wallets and Exchange Wallets. All other features and capabilities will be available to you once you have purchased our paid plans. 
 
-For paid plans, once you reach your usage limits, you will need to pay overage charges for any usage exceeding the limits at the corresponding unit price. In such cases, you have the option to purchase add-on packages at a discounted rate or upgrade to a higher-tier plan.
+For paid plans, once you reach your usage limits, you will need to pay overage charges for any usage exceeding the limits at the corresponding unit price. In such cases, you have the option to purchase add-on packages at a discounted rate, or [contact the sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) to upgrade to a higher-tier plan.

--- a/en/portal/bills-and-payments/manage-pricing-plan.mdx
+++ b/en/portal/bills-and-payments/manage-pricing-plan.mdx
@@ -19,7 +19,7 @@ It is recommended that you purchase add-on packages or upgrade to a higher-tier 
 
 ## Upgrade a pricing plan
 
-[Reach out to our sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) if you want to upgrade your pricing plan.
+If your organization has an active paid Starter or Standard plan and you want to upgrade to a higher-tier plan, [reach out to the sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales). Self-service plan upgrades are not available for organizations that already have an active paid plan.
 
 ## Purchase add-on packages
 

--- a/en/portal/bills-and-payments/purchase-pricing-plan.mdx
+++ b/en/portal/bills-and-payments/purchase-pricing-plan.mdx
@@ -19,14 +19,21 @@ Using MPC wallets, Custodial Wallets and Exchange Wallets on Enterprise Plan, yo
 - Shareholder or Ultimate Beneficial Owner (UBO) information.
 
 ## Purchase a Starter or Standard plan
-KYC verification is not required for using MPC wallets on both Starter and Standard Plans.
-Follow the steps below to purchase a Starter or Standard plan for MPC Wallets on Cobo Portal. 
+
+<Note>This self-service purchase flow applies only when your organization is on a free trial (including after trial expiry) or has no active pricing plan. If your organization already has an active paid Starter or Standard plan and you want to switch to a higher tier, contact the [sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales) instead.</Note>
+
+KYC verification is not required for purchasing Starter or Standard plans for MPC Wallets.
+Follow the steps below to purchase a Starter or Standard plan for MPC Wallets on Cobo Portal.
 
 1. Log into [Cobo Portal](https://portal.cobo.com/login).
 2. Click your profile avatar in the top-right corner, and choose **Pricing Plans**. 
 3. Select **MPC Wallets**.
-4. Click **Upgrade** or **Select Pricing Plan**, as shown on the screen.
+4. Click **Upgrade** (shown when you are on a free trial) or **Select Pricing Plan** (shown when your organization has no active plan), as shown on the screen.
 5. On the **Select Pricing Plan** dialog, select either the **Wallet-as-a-Service** or **Treasury Management** tab, then click **Activate** under the pricing plan you want to purchase.
 6. On the **Activate Pricing Plan** dialog, check the checkbox next to the service agreement, select a billing cycle, then click **Pay**.
 7. <PaymentMethods />
+
+## Upgrade an existing paid plan
+
+If your organization already has an active paid Starter or Standard plan and you want to upgrade to a higher-tier plan, [contact the sales team](https://www.cobo.com/book-demo/?utm_source=product-manual&utm_medium=product&utm_campaign=pricing-plan-intro&utm_content=enterprise-contact-sales). Self-service plan upgrades are not available for organizations that already have an active paid plan.
     


### PR DESCRIPTION
## 背景

Phabricator [T98399](https://pha.1cobo.com/T98399)：Manual 只描述了"尚未购买套餐"的首次购买流程，没有区分"已有生效套餐要升级"。Portal Agent 因此把首次购买流程错误泛化，告诉已有 Starter 套餐的客户可以在 Portal 自助升级到 Standard，给出了 `Pricing Plans → Upgrade → Activate → Pay → Fee Station` 这条并不存在的路径，客户在 Portal 找不到对应按钮。

由 Workmate `my-doc-writing-core` playbook 生成(run `run_f7cacc1c2c2f4e80`)。

## 改动

run 除了工单指定的范围，还查出了两处**文档本身就写错了**的地方：

**1. `introduction.mdx`(EN/CN)—— 现有表述与实际产品行为矛盾**
- Pricing Plans tab 描述里的"upgrade or downgrade as needed / 根据需要升级或降级" → 删除(降级当前不支持)
- "upgrade to a higher tier at any time / 随时升级到更高等级的套餐" → 改为需联系销售
- "self-upgrade to the Starter or Standard plan at any time / 在产品内随时自主升级" → 改为"试用期内/结束后可自助**开通**入门版或标准版；已开通付费套餐后如需切换更高等级需联系销售"
- 顺带修了标题拼写与大小写:`How to Start a Freetrial and Upgrade` → `How to start a free trial and purchase a plan`

**2. `purchase-pricing-plan.mdx`(EN/CN)—— 首次购买流程缺少适用范围声明**
- 章节开头加 `<Note>`：该自助购买流程仅适用于处于免费试用期(含试用期已结束)或尚未开通任何付费套餐的团队
- 第 4 步补上按钮出现条件:**Upgrade**(处于免费试用期时显示)/ **Select Pricing Plan**(尚未开通任何套餐时显示)
- 新增章节「Upgrade an existing paid plan / 升级已有付费套餐」

**3. `manage-pricing-plan.mdx`(EN/CN)**
- 「Upgrade a pricing plan」章节明确：已开通付费 Starter/Standard 的组织需联系销售，且已开通付费套餐后不支持在产品内自助升级

## 待确认事项

**工单建议文案里的折算说明本次未写入。** 工单原文包含"原套餐尚未使用部分的费用将根据实际升级方案进行折算"，但折算属于商务政策、无代码或 spec 出处，按约定未落地。如果这条口径已经确定可对外，请告知后单独补。

其余按工单要求排除的内容也均未写入：未来自助升级的支持范围与上线时间、具体折算公式、升级价格、降级与退款规则(仅说明当前不支持)。
